### PR TITLE
Use ref demonstration

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import MeuComponente from './components/useState'; // adaptar para cada hook
+import MeuComponente from './components/useRef'; // adaptar para cada hook
 import './App.css';
 
 function App() {

--- a/src/components/useRef.js
+++ b/src/components/useRef.js
@@ -6,26 +6,34 @@ function TemplateComponent() {
   const [number, setNumber] = useState(0); //
 
   const numberRef = useRef(0); // ao usar o useRef, o que seria o nosso setState é current.
-
+  const buttonRef = useRef()
   // A forma de atribuir valor a uma constante useRef é semelhante ao useState:
   // invés de usar: state = setState(novo-estado)
   // usamos: estado.current = novo-estado
 
-  console.log(numberRef)
+
+  // Não re-renderiza o componente a cada atualização de estado
   useEffect(() => {
     // setNumber((prevNumber) => prevNumber + 1); O setNumber cria um loop infinito
     numberRef.current = numberRef.current + 1; // Já o useRef impede a re-renderização da página, não criando o loop
   })
+
+
+  // Referência para elementos do DOM
+  useEffect(() => {
+    // buttonRef.current -> nesse ponto p useRef se comportar exatamente como um querySelector e agora vc tem acesso a todas as funções originalmente do DOM. Vc tem controle sobre o comportamento do botão, além do controle do que acontece quando ele é clicado como é o caso do onClick(). Exemplo:
+    buttonRef.current.click() // Essa manipulação de DOM gera um click automatico no botão, que dentro desse useEffect vai ser realizado sempre que o componente for montado. Você pode usar para ativar um botão assim que o usuário entrar na tela do seu componente ou você pode renderizar um componente de formulário com o 1º input do formulário já selecionado por exemplo. Lembre-se o useRef usado dessa forma te dá acesso a todo poder de manipulação de DOM, não só com tags button. Serve para qualquer tag e aí vc usa um atributo que faça sentido para aquela tag
+  }, [])
+
 
   return (
     <div>
         <h1>O componente foi re-montado {number} vezes</h1>
         <h1>O número do useRef é: {numberRef.current}</h1>
         <h1>O contador é: {count}</h1>
-        <button onClick={
-          () => {
-            setCount((prevCount) => prevCount + 1)} // adiciona +1 ao valor antigo do estado contador
-          }>+1</button>
+        <button
+        ref={buttonRef} // Toda tag jsx tem o atributo "ref". Que aceita o useRef para fazer a ligação entre a referência e o input
+        onClick={() => {setCount((prevCount) => prevCount + 1)}}>+1</button>
     </div>
   );
 }

--- a/src/components/useRef.js
+++ b/src/components/useRef.js
@@ -1,0 +1,22 @@
+// TemplateComponent.js
+import React, {useState} from 'react';
+
+function TemplateComponent() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <div>
+        <h1>O contador é: {count}</h1>
+        <button onClick={
+          () => {
+            setCount((prevCount) => prevCount + 1)} // adiciona +1 ao valor antigo do estado contador
+          }>+1</button>
+    </div>
+  );
+}
+
+export default TemplateComponent;
+
+// Toda vez que o estado é alterado, o componente é renderizado novamente. Lembra que a requisição a uma API que guarda os dados num estado precisa vir no useEffect por causa disso, pra não causar loop infinito.
+
+// Pensando nisso, o useRef permite a mudança do valor mas bloqueia a re renderização do componente. 

--- a/src/components/useRef.js
+++ b/src/components/useRef.js
@@ -6,7 +6,9 @@ function TemplateComponent() {
   const [number, setNumber] = useState(0); //
 
   const numberRef = useRef(0); // ao usar o useRef, o que seria o nosso setState é current.
-  const buttonRef = useRef()
+  const buttonRef = useRef();
+  const oldCountRef = useRef(); // referência para ser o valor anterior que estava na variável count
+
   // A forma de atribuir valor a uma constante useRef é semelhante ao useState:
   // invés de usar: state = setState(novo-estado)
   // usamos: estado.current = novo-estado
@@ -26,14 +28,24 @@ function TemplateComponent() {
   }, [])
 
 
+  // Referência do valor anterior
+    // Posso usar o useRef para salvar o valor anterior de uma variável
+    useEffect(() => {
+      oldCountRef.current = count;
+    }, [count]) // o useEffect é executado a cada alteração no count
+    // útil para mapear o valor antigo de uma variável. Exemplo: criar botão "Desfazer" tal coisa, tgl?!
+
   return (
     <div>
         <h1>O componente foi re-montado {number} vezes</h1>
-        <h1>O número do useRef é: {numberRef.current}</h1>
         <h1>O contador é: {count}</h1>
+        <h1>O contador anterior era: {oldCountRef.current}</h1> {/* lembrar de SEMPRE colocar o nome da variável de referencia + .current */}
         <button
         ref={buttonRef} // Toda tag jsx tem o atributo "ref". Que aceita o useRef para fazer a ligação entre a referência e o input
         onClick={() => {setCount((prevCount) => prevCount + 1)}}>+1</button>
+
+        <h1>O número do useRef é: {numberRef.current}</h1>
+
     </div>
   );
 }

--- a/src/components/useRef.js
+++ b/src/components/useRef.js
@@ -1,11 +1,26 @@
 // TemplateComponent.js
-import React, {useState} from 'react';
+import React, {useState, useEffect, useRef} from 'react';
 
 function TemplateComponent() {
   const [count, setCount] = useState(0);
+  const [number, setNumber] = useState(0); //
+
+  const numberRef = useRef(0); // ao usar o useRef, o que seria o nosso setState é current.
+
+  // A forma de atribuir valor a uma constante useRef é semelhante ao useState:
+  // invés de usar: state = setState(novo-estado)
+  // usamos: estado.current = novo-estado
+
+  console.log(numberRef)
+  useEffect(() => {
+    // setNumber((prevNumber) => prevNumber + 1); O setNumber cria um loop infinito
+    numberRef.current = numberRef.current + 1; // Já o useRef impede a re-renderização da página, não criando o loop
+  })
 
   return (
     <div>
+        <h1>O componente foi re-montado {number} vezes</h1>
+        <h1>O número do useRef é: {numberRef.current}</h1>
         <h1>O contador é: {count}</h1>
         <button onClick={
           () => {
@@ -19,4 +34,4 @@ export default TemplateComponent;
 
 // Toda vez que o estado é alterado, o componente é renderizado novamente. Lembra que a requisição a uma API que guarda os dados num estado precisa vir no useEffect por causa disso, pra não causar loop infinito.
 
-// Pensando nisso, o useRef permite a mudança do valor mas bloqueia a re renderização do componente. 
+// Pensando nisso, o useRef permite a mudança do valor mas bloqueia a re renderização do componente. Sendo um recurso útil quando pensamos em


### PR DESCRIPTION
O hook `useRef` do React é uma ferramenta versátil que pode ser utilizada em diversos contextos para melhorar o controle e o desempenho de componentes React. Neste contexto, destaco três maneiras de usar o `useRef`, cada uma com suas próprias aplicações específicas.

### Evitar re-renderização constante:

- O `useRef` é útil para evitar re-renderizações desnecessárias de um componente quando você precisa armazenar valores entre renderizações, mas esses valores não devem afetar o ciclo de vida do componente ou causar novos renders.
- Ao atribuir um valor a um objeto `ref`, ele persiste entre as renderizações do componente sem acionar um novo render quando o valor do objeto `ref` é atualizado.
- Isso é útil quando você deseja manter uma referência constante a um valor, mas não quer que as mudanças nesse valor acionem re-renderizações.

### Referenciar elementos do DOM:

- O `useRef` é amplamente utilizado para referenciar elementos do DOM em componentes React.
- Você pode criar um objeto `ref` e atribuí-lo a um elemento HTML usando a propriedade `ref` do elemento.
- Isso permite que você acesse e manipule o elemento diretamente, por exemplo, para executar animações, medir dimensões ou adicionar event listeners.

### Salvar e resgatar o valor anterior imediato:

- O `useRef` pode ser usado para salvar e acessar o valor anterior imediato de uma variável dentro de um componente funcional.
- Você pode atualizar o valor de um objeto `ref` no `useEffect` após o render inicial do componente e, em seguida, acessar o valor anterior armazenado no objeto `ref` nas renderizações subsequentes.
- Isso é útil quando você precisa comparar o valor atual com o valor anterior para tomar decisões ou realizar ações específicas com base nas mudanças de estado.